### PR TITLE
Play initial audio directly instead of queueing

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -72,7 +72,7 @@ app.intent("GetVideoIntent", {
                                         'token': metadata.id,
                                         'offsetInMilliseconds': 0
                                     };
-                                    response.audioPlayerPlayStream('ENQUEUE', stream);
+                                    response.audioPlayerPlayStream('REPLACE_ALL', stream);
                                     response.card({
                                         'type': 'Simple',
                                         'title': 'Search for "' + query + '"',


### PR DESCRIPTION
ENQUEUEing an audio stream requires the 'expectedPreviousToken' to be set (see https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/custom-audioplayer-interface-reference#playbackfailed), so use REPLACE_ALL instead